### PR TITLE
Fixed product version cancellation date

### DIFF
--- a/src/UKHO.SalesCatalogueStub.Api.Tests/ProductEditionServiceGetVersionsTests.cs
+++ b/src/UKHO.SalesCatalogueStub.Api.Tests/ProductEditionServiceGetVersionsTests.cs
@@ -724,7 +724,7 @@ namespace UKHO.SalesCatalogueStub.Api.Tests
                         EditionNumber = editionNumber.ToString(),
                         UpdateNumber = updateNumber,
                         LastReissueUpdateNumber = LastReissueUpdateNumber,
-                        LastUpdated = lastUpdated
+                        LastUpdateIssueDate = lastUpdated
                     }
                 },
                 ProductType = new ProductType { Name = productType }

--- a/src/UKHO.SalesCatalogueStub.Api/Services/ProductEditionService.cs
+++ b/src/UKHO.SalesCatalogueStub.Api/Services/ProductEditionService.cs
@@ -236,7 +236,8 @@ namespace UKHO.SalesCatalogueStub.Api.Services
                 {
                     case ProductEditionStatusEnum.Cancelled:
                         {
-                            var productCancelledDate = productDbMatch.LastUpdateIssueDate.Value;
+                            var productCancelledDate = productDbMatch.LastUpdateIssueDate ?? productDbMatch.EditionDate;
+                            
                             var days = DateTime.Today.Subtract(productCancelledDate.Date).TotalDays;
 
                             if (days > 365)

--- a/src/UKHO.SalesCatalogueStub.Api/Services/ProductEditionService.cs
+++ b/src/UKHO.SalesCatalogueStub.Api/Services/ProductEditionService.cs
@@ -236,22 +236,26 @@ namespace UKHO.SalesCatalogueStub.Api.Services
                 {
                     case ProductEditionStatusEnum.Cancelled:
                         {
-                            var productCancelledDate = productDbMatch.LastUpdateIssueDate ?? productDbMatch.EditionDate;
-                            
-                            var days = DateTime.Today.Subtract(productCancelledDate.Date).TotalDays;
-
-                            if (days > 365)
+                            if (productDbMatch.LastUpdateIssueDate.HasValue)
                             {
-                                // Old product, do not return with data; just add to the RequestedProductsNotReturned
-                                productResponse.ProductCounts.RequestedProductsNotReturned.Add(
-                                    new RequestedProductsNotReturned
-                                    {
-                                        ProductName = requestProduct.ProductName,
-                                        Reason = RequestedProductsNotReturned.ReasonEnum.NoDataAvailableForCancelledProductEnum
-                                    });
+                                var productCancelledDate = productDbMatch.LastUpdateIssueDate.Value;
 
-                                continue;
+                                var days = DateTime.Today.Subtract(productCancelledDate.Date).TotalDays;
 
+                                if (days > 365)
+                                {
+                                    // Old product, do not return with data; just add to the RequestedProductsNotReturned
+                                    productResponse.ProductCounts.RequestedProductsNotReturned.Add(
+                                        new RequestedProductsNotReturned
+                                        {
+                                            ProductName = requestProduct.ProductName,
+                                            Reason = RequestedProductsNotReturned.ReasonEnum
+                                                .NoDataAvailableForCancelledProductEnum
+                                        });
+
+                                    continue;
+
+                                }
                             }
 
                             matchedProduct.Cancellation = new Cancellation

--- a/src/UKHO.SalesCatalogueStub.Api/Services/ProductEditionService.cs
+++ b/src/UKHO.SalesCatalogueStub.Api/Services/ProductEditionService.cs
@@ -236,7 +236,7 @@ namespace UKHO.SalesCatalogueStub.Api.Services
                 {
                     case ProductEditionStatusEnum.Cancelled:
                         {
-                            var productCancelledDate = productDbMatch.LastUpdated.Value;
+                            var productCancelledDate = productDbMatch.LastUpdateIssueDate.Value;
                             var days = DateTime.Today.Subtract(productCancelledDate.Date).TotalDays;
 
                             if (days > 365)


### PR DESCRIPTION
## UKHO.SalesCatalogueStub.Api

- ProductEditionService.cs: use LastUpdateIssueDate column from productEditions table to calculate when a product was cancelled

## UKHO.SalesCatalogueStub.Api.Tests

- ProductEditionServiceGetVersionsTests.cs: Updated unit tests for product version to use LastUpdateIssueDate 