### PR TITLE
Amend last modified header to include a hyphen

### DIFF
--- a/src/UKHO.SalesCatalogueStub.Api/Controllers/CatalogueApiController.cs
+++ b/src/UKHO.SalesCatalogueStub.Api/Controllers/CatalogueApiController.cs
@@ -57,7 +57,7 @@ namespace UKHO.SalesCatalogueStub.Api.Controllers
         {
             var checkIfCatalogueModified = await _productEditionService.CheckIfCatalogueModified(ifModifiedSince);
 
-            Response?.Headers.Add("LastModified", checkIfCatalogueModified.dateEntered?.ToString());
+            Response?.Headers.Add("Last-Modified", checkIfCatalogueModified.dateEntered?.ToString());
 
             if (!checkIfCatalogueModified.isModified)
             {


### PR DESCRIPTION
The last modified header that gets added to the return requires a hyphen to match the schema provided in the Swagger doc.