### PR TITLE
Add catalog-info.yaml config file for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,8 +2,14 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: sales-catalogue-stub
+  description: A temporary service to enable the creation of the ADDS Exchange Set Service
   annotations:
     github.com/project-slug: UKHO/sales-catalogue-stub
 spec:
-  type: other
-  lifecycle: unknown
+  type: service
+  lifecycle: experimental
+  owner: Tamatoa
+  system: ADDS
+  providesApis:
+    - CatalogueApi
+    - ExchangeServiceApi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sales-catalogue-stub
+  annotations:
+    github.com/project-slug: UKHO/sales-catalogue-stub
+spec:
+  type: other
+  lifecycle: unknown


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Bridge software catalog](https://poc.ukho.dev).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).